### PR TITLE
Implement feature to create rename and remove file.

### DIFF
--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -1,10 +1,19 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 
-export async function GET(req: Request) {
+function getWorkingDirectory(): string {
   // use the root folder of the project.
   // todo: should be able to let user select customized folder.
-  const baseDir = process.cwd();
+  return process.cwd();
+}
+
+/**
+ * Retrieves the directory contents for a given path.
+ * @param {Request} req - The request object containing the path query parameter.
+ * @returns {Promise<Response>} A JSON response with the directory contents or an error message.
+ */
+export async function GET(req: Request): Promise<Response> {
+  const baseDir = getWorkingDirectory();
   const { searchParams } = new URL(req.url);
   const targetPath = searchParams.get('path') || '';
 
@@ -22,21 +31,108 @@ export async function GET(req: Request) {
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (error) {
-    let errorMessage = 'An unknown error occurred';
+    return errorResponse(error, 'Could not read directory');
+  }
+}
 
-    if (error instanceof Error) {
-      errorMessage = error.message;
+/**
+ * Creates a new file or directory.
+ * @param {Request} req - The request object containing the name and type (file/directory).
+ * @returns {Promise<Response>} A JSON response indicating success or failure.
+ */
+export async function POST(req: Request): Promise<Response> {
+  const baseDir = getWorkingDirectory();
+  const { path: targetPath, name, type } = await req.json();
+
+  try {
+    const targetFolder = path.resolve(baseDir, targetPath);
+    const stat = await fs.stat(targetFolder).catch(() => null);
+    if (!stat || !stat.isDirectory()) {
+      throw new Error('Directory does not exist');
     }
 
-    return new Response(
-      JSON.stringify({
-        error: 'Could not read directory',
-        details: errorMessage,
-      }),
-      {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+    const filePath = path.join(targetPath, name);
+    switch (type) {
+      case 'file':
+        await fs.writeFile(filePath, '');
+        break;
+      case 'directory':
+        await fs.mkdir(filePath, { recursive: true });
+        break;
+      default:
+        throw new Error('Invalid type. Use "file" or "directory".');
+    }
+
+    return new Response(JSON.stringify({ success: true }), { status: 201 });
+  } catch (error) {
+    return errorResponse(error, 'Could not create file/directory');
   }
+}
+
+/**
+ * Renames a file or directory.
+ * @param {Request} req - The request object containing the old and new names.
+ * @returns {Promise<Response>} A JSON response indicating success or failure.
+ */
+export async function PATCH(req: Request): Promise<Response> {
+  const baseDir = getWorkingDirectory();
+  const { path: targetPath, oldName, newName } = await req.json();
+
+  try {
+    const oldPath = path.resolve(baseDir, targetPath, oldName);
+    const oldStat = await fs.stat(oldPath).catch(() => null);
+    if (!oldStat) {
+      throw new Error('File or Directory does not exist.');
+    }
+
+    const newPath = path.resolve(baseDir, targetPath, newName);
+    const newStat = await fs.stat(newPath).catch(() => null);
+    if (newStat) {
+      throw new Error('File or Directory already exist.');
+    }
+
+    await fs.rename(oldPath, newPath);
+
+    return new Response(JSON.stringify({ success: true }));
+  } catch (error) {
+    return errorResponse(error, 'Could not rename file/directory');
+  }
+}
+
+/**
+ * Deletes a file or directory.
+ * @param {Request} req - The request object containing the target path.
+ * @returns {Promise<Response>} A JSON response indicating success or failure.
+ */
+export async function DELETE(req: Request): Promise<Response> {
+  const baseDir = getWorkingDirectory();
+  const { path: targetPath, name } = await req.json();
+
+  try {
+    const fullPath = path.join(baseDir, targetPath, name);
+    const stat = await fs.lstat(fullPath);
+
+    if (stat.isDirectory()) {
+      await fs.rmdir(fullPath, { recursive: true });
+    } else if (stat.isFile()) {
+      await fs.rm(fullPath, { recursive: true });
+    } else {
+      throw new Error('File or Directory does not exist.');
+    }
+
+    return new Response(JSON.stringify({ success: true }));
+  } catch (error) {
+    return errorResponse(error, 'Could not delete file/directory');
+  }
+}
+
+function errorResponse(error: unknown, message: string) {
+  let errorMessage = 'An unknown error occurred';
+  if (error instanceof Error) {
+    errorMessage = error.message;
+  }
+  return new Response(JSON.stringify({ error: message, details: errorMessage }), {
+    status: 500,
+    headers: { 'Content-Type': 'application/json' },
+  });
 }

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,0 +1,33 @@
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@mui/material';
+import WarningIcon from '@mui/icons-material/Warning';
+
+interface ConfirmModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  message: string;
+  confirmButtonText: string;
+}
+
+export default function ConfirmModal({
+  open,
+  onClose,
+  onConfirm,
+  message,
+  confirmButtonText,
+}: ConfirmModalProps) {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>
+        <WarningIcon color='error' /> Confirm
+      </DialogTitle>
+      <DialogContent>{message}</DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={onConfirm} variant='contained' color='error'>
+          {confirmButtonText}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/workspace/components/CreateDirectoryModal.tsx
+++ b/src/workspace/components/CreateDirectoryModal.tsx
@@ -1,0 +1,43 @@
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  TextField,
+  DialogActions,
+  Button,
+} from '@mui/material';
+import { useState } from 'react';
+import Typography from '@mui/material/Typography';
+import * as React from 'react';
+
+interface DirectoryModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (name: string) => void;
+  defaultValue?: string;
+}
+
+export default function CreateDirectoryModal({
+  open,
+  onClose,
+  onSubmit,
+  defaultValue = '',
+}: DirectoryModalProps) {
+  const [name, setName] = useState(defaultValue);
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Create</DialogTitle>
+      <DialogContent>
+        <Typography>Create a new directory with name.</Typography>
+        <TextField autoFocus fullWidth value={name} onChange={(e) => setName(e.target.value)} />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={() => onSubmit(name)} variant='contained'>
+          OK
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/workspace/components/CreateFileModal.tsx
+++ b/src/workspace/components/CreateFileModal.tsx
@@ -1,0 +1,43 @@
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  TextField,
+  DialogActions,
+  Button,
+} from '@mui/material';
+import { useState } from 'react';
+import Typography from '@mui/material/Typography';
+import * as React from 'react';
+
+interface FileModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (name: string) => void;
+  defaultValue?: string;
+}
+
+export default function CreateFileModal({
+  open,
+  onClose,
+  onSubmit,
+  defaultValue = '',
+}: FileModalProps) {
+  const [name, setName] = useState(defaultValue);
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Create</DialogTitle>
+      <DialogContent>
+        <Typography>Create a new file with name.</Typography>
+        <TextField autoFocus fullWidth value={name} onChange={(e) => setName(e.target.value)} />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={() => onSubmit(name)} variant='contained'>
+          OK
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/workspace/components/DirectoryExplorer.tsx
+++ b/src/workspace/components/DirectoryExplorer.tsx
@@ -1,7 +1,12 @@
+import { MouseEvent, useState } from 'react';
 import { SimpleTreeView, TreeItem } from '@mui/x-tree-view';
-import { CircularProgress } from '@mui/material';
-import {useDirectoryStore, FileItem, getPath, FileType} from '../store/directoryStore';
+import { CircularProgress, Menu, MenuItem } from '@mui/material';
+import { FileItem, FileType, getPath, useDirectoryStore } from '../store/directoryStore';
 import { useExpandedKeys } from '../hooks/useExpandedDirectoryPaths';
+import CreateFileModal from './CreateFileModal';
+import RenameFileModal from './RenameFileModal';
+import ConfirmModal from '@/components/ConfirmModal';
+import CreateDirectoryModal from '@/workspace/components/CreateDirectoryModal';
 
 function getLabel(item: FileItem): string {
   switch (item.type) {
@@ -14,28 +19,44 @@ function getLabel(item: FileItem): string {
   }
 }
 
+enum OpenModalAction {
+  CreateFile = 'create_file',
+  CreateDirectory = 'create_directory',
+  Rename = 'rename',
+  Delete = 'delete',
+}
+
+function renderTreeInDirectory(
+  item: FileItem,
+  currentDirectory: FileItem[],
+  onItemClick: (path: FileItem[]) => void,
+  onContextMenuClick: (event: MouseEvent, itemPath: FileItem[]) => void
+) {
+  if (item.type != FileType.Directory) {
+    return null;
+  } else if (!item.children) {
+    return <TreeItem itemId={`loading-${item.name}`} label='Loading...' />;
+  } else {
+    return renderTree(item.children, currentDirectory, onItemClick, onContextMenuClick);
+  }
+}
+
 function renderTree(
   items: FileItem[],
   parentDirectory: FileItem[],
-  onItemClick: (path: FileItem[]) => void
+  onItemClick: (path: FileItem[]) => void,
+  onContextMenuClick: (event: MouseEvent, itemPath: FileItem[]) => void
 ) {
-  function generateTemplate(
-    item: FileItem,
-    currentDirectory: FileItem[],
-    onItemClick: (path: FileItem[]) => void
-  ) {
-    if (item.type != FileType.Directory) {
-      return null;
-    } else if (!item.children) {
-      return <TreeItem itemId={`loading-${item.name}`} label='Loading...' />;
-    } else {
-      return renderTree(item.children, currentDirectory, onItemClick);
-    }
-  }
-
   return items.map((item) => {
     const currentDirectory = [...parentDirectory, item];
     const currentPath = getPath(currentDirectory);
+
+    function handleContextMenuClick(event: MouseEvent) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      onContextMenuClick(event, currentDirectory);
+    }
 
     return (
       <TreeItem
@@ -43,16 +64,40 @@ function renderTree(
         itemId={currentPath}
         label={getLabel(item)}
         onClick={() => item.type === FileType.Directory && onItemClick(currentDirectory)}
+        onContextMenu={handleContextMenuClick}
       >
-        {generateTemplate(item, currentDirectory, onItemClick)}
+        {renderTreeInDirectory(item, currentDirectory, onItemClick, onContextMenuClick)}
       </TreeItem>
     );
   });
 }
 
+function getDirectory(fileItems: FileItem[]): FileItem[] {
+  switch (fileItems[fileItems.length - 1].type) {
+    case FileType.Directory:
+      return fileItems;
+    case FileType.File:
+      return fileItems.slice(0, -1);
+    default:
+      throw new Error(`Unknown file type ${fileItems.length - 1}`);
+  }
+}
+
 export default function DirectoryExplorer() {
-  const { rootItems, loading, handleItemClick } = useDirectoryStore();
+  const { rootItems, loading, handleItemClick, createItem, renameItem, deleteItem } =
+    useDirectoryStore();
   const { expandedKeys, toggleExpand } = useExpandedKeys();
+
+  const [contextMenu, setContextMenu] = useState<{
+    position: {
+      x: number;
+      y: number;
+    } | null;
+    selectedItemPath: FileItem[];
+  } | null>(null);
+
+  const [dialogType, setDialogType] = useState<OpenModalAction | null>(null);
+  const [oldFileName, setOldFileName] = useState('');
 
   function handleDirectoryClick(itemPath: FileItem[]): void {
     handleItemClick(itemPath).then(() => {
@@ -61,15 +106,156 @@ export default function DirectoryExplorer() {
     });
   }
 
+  function handleContextMenu(event: MouseEvent, itemPath: FileItem[]) {
+    setContextMenu({
+      position: {
+        x: event.clientX,
+        y: event.clientY,
+      },
+      selectedItemPath: itemPath,
+    });
+  }
+
+  function handleMenuClose() {
+    if (!contextMenu) {
+      throw new Error('Context menu does not open.');
+    }
+
+    setContextMenu({
+      position: null,
+      selectedItemPath: contextMenu?.selectedItemPath,
+    });
+  }
+
+  function openDialog(type: OpenModalAction, itemPath: FileItem[]) {
+    setDialogType(type);
+
+    // use the selected file if you want to rename the file.
+    const oldFileName = type === OpenModalAction.Rename ? itemPath[itemPath.length - 1].name : '';
+    setOldFileName(oldFileName);
+    handleMenuClose();
+  }
+
+  function handleCreateFile(fileName: string): void {
+    if (!contextMenu) return;
+
+    // if user click the item and trying to create the item, should create in the parent folder.
+    const itemDirectory = getDirectory(contextMenu.selectedItemPath);
+
+    createItem(itemDirectory, fileName, FileType.File).then(() => {
+      console.log('Creating new file in:', getPath(itemDirectory), 'with name:', oldFileName);
+    });
+
+    handleDialogClose();
+  }
+
+  function handCreateDirectory(fileName: string): void {
+    if (!contextMenu) return;
+
+    debugger;
+    console.log('create directory');
+
+    // if user click the item and trying to create the item, should create in the parent folder.
+    const itemDirectory = getDirectory(contextMenu.selectedItemPath);
+
+    createItem(itemDirectory, fileName, FileType.Directory).then(() => {
+      console.log('Creating new file in:', getPath(itemDirectory), 'with name:', oldFileName);
+      handleDialogClose();
+    });
+  }
+
+  function handleRename(fileName: string): void {
+    if (!contextMenu) return;
+
+    const parentFolder = contextMenu.selectedItemPath.slice(0, -1);
+
+    renameItem(parentFolder, oldFileName, fileName).then(() => {
+      console.log('Renaming:', getPath(parentFolder), 'from:', oldFileName, 'to:', oldFileName);
+      handleDialogClose();
+    });
+  }
+
+  function handleDelete(): void {
+    if (!contextMenu) return;
+
+    const parentFolder = contextMenu.selectedItemPath.slice(0, -1);
+    const fileName = contextMenu.selectedItemPath[contextMenu.selectedItemPath.length - 1].name;
+
+    deleteItem(parentFolder, fileName).then(() => {
+      console.log('Deleting:', getPath(parentFolder));
+      handleDialogClose();
+    });
+  }
+
+  function handleDialogClose() {
+    setDialogType(null);
+    setOldFileName('');
+    setContextMenu(null);
+  }
+
   return (
     <div className='p-5'>
       {loading && !rootItems ? (
         <CircularProgress />
       ) : (
         <SimpleTreeView aria-label='directory structure' expandedItems={Array.from(expandedKeys)}>
-          {renderTree(rootItems, [], handleDirectoryClick)}
+          {renderTree(rootItems, [], handleDirectoryClick, handleContextMenu)}
         </SimpleTreeView>
       )}
+
+      {/* Context menu for edit the file or directory */}
+      <Menu
+        open={Boolean(contextMenu?.position)}
+        onClose={handleMenuClose}
+        anchorReference='anchorPosition'
+        anchorPosition={
+          contextMenu?.position
+            ? { top: contextMenu.position.y, left: contextMenu.position.x }
+            : undefined
+        }
+      >
+        <MenuItem
+          onClick={() => openDialog(OpenModalAction.CreateFile, contextMenu!.selectedItemPath)}
+        >
+          Create File
+        </MenuItem>
+        <MenuItem
+          onClick={() => openDialog(OpenModalAction.CreateDirectory, contextMenu!.selectedItemPath)}
+        >
+          Create Directory
+        </MenuItem>
+        <MenuItem onClick={() => openDialog(OpenModalAction.Rename, contextMenu!.selectedItemPath)}>
+          Rename
+        </MenuItem>
+        <MenuItem onClick={() => openDialog(OpenModalAction.Delete, contextMenu!.selectedItemPath)}>
+          Delete
+        </MenuItem>
+      </Menu>
+
+      {/* modal for doing the action. */}
+      <CreateFileModal
+        open={dialogType === OpenModalAction.CreateFile}
+        onClose={handleDialogClose}
+        onSubmit={handleCreateFile}
+      />
+      <CreateDirectoryModal
+        open={dialogType == OpenModalAction.CreateDirectory}
+        onClose={handleDialogClose}
+        onSubmit={handCreateDirectory}
+      />
+      <RenameFileModal
+        open={dialogType === OpenModalAction.Rename}
+        onClose={handleDialogClose}
+        onSubmit={handleRename}
+        oldFileName={oldFileName}
+      />
+      <ConfirmModal
+        open={dialogType === OpenModalAction.Delete}
+        onClose={handleDialogClose}
+        onConfirm={handleDelete}
+        message='Remove the file?'
+        confirmButtonText='Delete'
+      />
     </div>
   );
 }

--- a/src/workspace/components/RenameFileModal.tsx
+++ b/src/workspace/components/RenameFileModal.tsx
@@ -1,0 +1,42 @@
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  TextField,
+  DialogActions,
+  Button,
+} from '@mui/material';
+import { useEffect, useState } from 'react';
+import Typography from '@mui/material/Typography';
+import * as React from 'react';
+
+interface FileModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (name: string) => void;
+  oldFileName: string;
+}
+
+export default function RenameFileModal({ open, onClose, onSubmit, oldFileName }: FileModalProps) {
+  const [name, setName] = useState(oldFileName);
+
+  useEffect(() => {
+    setName(oldFileName);
+  }, [oldFileName]);
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Rename the file</DialogTitle>
+      <DialogContent>
+        <Typography>Rename the file.</Typography>
+        <TextField autoFocus fullWidth value={name} onChange={(e) => setName(e.target.value)} />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={() => onSubmit(name)} variant='contained'>
+          OK
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/workspace/store/directoryStore.ts
+++ b/src/workspace/store/directoryStore.ts
@@ -84,9 +84,71 @@ export function useDirectoryStore() {
     await fetchItems(getPath(itemPath));
   }
 
+  async function createItem(parentPath: FileItem[], name: string, type: FileType) {
+    const fullPath = getPath(parentPath);
+    try {
+      const res = await fetch('/api/files', {
+        method: 'POST',
+        body: JSON.stringify({ path: fullPath, name, type }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      if (!res.ok) {
+        throw new Error('Failed to create item');
+      }
+
+      await fetchItems(fullPath);
+    } catch (error) {
+      console.error('Failed to create item:', error);
+    }
+  }
+
+  async function renameItem(itemPath: FileItem[], oldName: string, newName: string) {
+    const fullPath = getPath(itemPath);
+
+    try {
+      const res = await fetch('/api/files', {
+        method: 'PATCH',
+        body: JSON.stringify({ path: fullPath, oldName, newName }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      if (!res.ok) {
+        throw new Error('Failed to rename item');
+      }
+
+      await fetchItems(getPath(itemPath));
+    } catch (error) {
+      console.error('Failed to rename item:', error);
+    }
+  }
+
+  async function deleteItem(itemPath: FileItem[], name: string) {
+    const fullPath = getPath(itemPath);
+
+    try {
+      const res = await fetch('/api/files', {
+        method: 'DELETE',
+        body: JSON.stringify({ path: fullPath, name: name }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      if (!res.ok) {
+        throw new Error('Failed to delete item');
+      }
+
+      await fetchItems(getPath(itemPath));
+    } catch (error) {
+      console.error('Failed to delete item:', error);
+    }
+  }
+
   return {
     rootItems,
     loading,
     handleItemClick,
+    createItem,
+    renameItem,
+    deleteItem,
   };
 }


### PR DESCRIPTION
What's added in this PR:

1. directory explorer support right-click to open the context menu:
  ![image](https://github.com/user-attachments/assets/2a1dddb3-1442-4a38-a12d-ecc0bc29361e)
2. If the user select create or rename, will create a modal for the user to input
  ![image](https://github.com/user-attachments/assets/73b864bc-4700-47d7-8597-8bde75b52302)
3. If the user select remove, will open the modal for confirmation.
  ![image](https://github.com/user-attachments/assets/b9e15a89-a45b-4b9c-92d3-6a2ff14152b3)

Here's the component this PR using:
- context menu: https://mui.com/material-ui/react-menu/?srsltid=AfmBOoqqipBkpiafqG1kClil5yFCC_5wDDloq6nNOiWHiSwVmhQ-8EO1
- modal: https://mui.com/material-ui/react-modal/?srsltid=AfmBOoricSYjgGVAHgJerP2X2_vNh0B2B2LYY0_-mRYKw2yvMqawlaXa